### PR TITLE
add some docs to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transform Metrics Repo
-
 See full install instructions on the (install page)[https://app.transformdata.io/install].
+
 ## Your First Metrics
 Transform uses Github Workflows to validate and commit new versions of your metrics configs to our service. In this template repo, we've already set up these workflows for you in the `/.github` directory.
 


### PR DESCRIPTION
### What
Turns out, distributing virtual env with binaries in them via git is not at all recommended. 

Instead, I added some documentation to help get people set up really quick with the CLI. It also explains how the Github workflows work a bit and encourage people to go to our install docs page.