### PR TITLE
Adds optional TRANSFORM_CONFIG_DIR

### DIFF
--- a/.github/scripts/validate.py
+++ b/.github/scripts/validate.py
@@ -17,6 +17,7 @@ else:
 
 COMMIT = os.getenv("GITHUB_SHA")
 TRANSFORM_API_KEY = os.getenv("TRANSFORM_API_KEY")
+TRANSFORM_CONFIG_DIR = os.getenv("TRANSFORM_CONFIG_DIR")
 
 def read_config_files(config_dir):
     """Read yaml files from config_dir. Returns (file name, file contents) per file in dir"""
@@ -37,7 +38,7 @@ def read_config_files(config_dir):
 
     return results
 
-yaml_files = read_config_files(".")
+yaml_files = read_config_files(TRANSFORM_CONFIG_DIR or ".")
 results = {'yaml_files': yaml_files}
 print(f"Files to upload: {yaml_files.keys()}")
 headers = {'Content-Type': 'application/json', 'Authorization': f'X-Api-Key {TRANSFORM_API_KEY}'}

--- a/.github/workflows/commit_configs.yaml
+++ b/.github/workflows/commit_configs.yaml
@@ -18,6 +18,7 @@ jobs:
       - name: Run commit script
         run: python ./.github/scripts/validate.py commit
         env:
+          TRANSFORM_CONFIG_DIR: ${{ secrets.TRANSFORM_CONFIG_DIR }} # TRANSFORM_CONFIG_DIR may be added to  repo secrets settings (repo-root is used otherwise)
           TRANSFORM_API_URL: ${{ secrets.TRANSFORM_API_URL }} # TRANSFORM_API_URL must be in repo secrets settings (or should we hardcode?)
           REPO: ${{ github.repository }}
           TRANSFORM_API_KEY: ${{ secrets.TRANSFORM_API_KEY }} # TRANSFORM_API_KEY must be in repo secrets settings

--- a/.github/workflows/validate_configs.yaml
+++ b/.github/workflows/validate_configs.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Run validate script
         run: python ./.github/scripts/validate.py validate
         env:
+          TRANSFORM_CONFIG_DIR: ${{ secrets.TRANSFORM_CONFIG_DIR }} # TRANSFORM_CONFIG_DIR may be added to  repo secrets settings (repo-root is used otherwise)
           TRANSFORM_API_URL: ${{ secrets.TRANSFORM_API_URL }} # TRANSFORM_API_URL must be in repo secrets settings (or should we hardcode?)
           REPO: ${{ github.repository }}
           TRANSFORM_API_KEY: ${{ secrets.TRANSFORM_API_KEY }} # TRANSFORM_API_KEY must be in repo secrets settings


### PR DESCRIPTION
# Changes
By setting TRANSFORM_CONFIG_DIR secret in their repo, customers can specify a directory within the repo that holds their transform configs.

# Testing
Copied this change to the transform repo, made a PR (https://github.com/transform-data/transform/pull/66/checks?check_run_id=2144161429) (checks passed), then added a dir "thorium" and set TRANSFORM_CONFIG_DIR = thorium (checks didn't pass because the configs i put in "thorium" were invalid)
- [x] Specs pass (or how you tested your changes)

# Security Implications
None
