### PR TITLE
Use TIMESTAMP instead of DATETIME type

### DIFF
--- a/example/customers.yaml
+++ b/example/customers.yaml
@@ -27,12 +27,12 @@ data_source:
   mutability:
     type: immutable
 
-  # CAST(col as datetime) not required when using columns from a data warehouse table or SQL statement based off of a table. It is used here for BigQuery to resolve improperly cast STRING data when using "UNION ALL" data.
+  # CAST(col as TIMESTAMP) not required when using columns from a data warehouse table or SQL statement based off of a table. It is used here for BigQuery to resolve improperly cast STRING data when using "UNION ALL" data.
   sql_query: |
     SELECT
       id_customer
       , country
-      , CAST(ds as DATETIME) AS ds
+      , CAST(ds as TIMESTAMP) AS ds
     FROM (
         SELECT
           'c500003'             AS id_customer

--- a/example/transactions.yaml
+++ b/example/transactions.yaml
@@ -94,7 +94,7 @@ data_source: # This section includes metadata on the data source and the source 
 
 # You can pass sql_table or sql_query. sql_table is the table from which the data source is constructed. You can also pass in the database name first.
 # sql_query allows you to aggregate or filter the data before passing it into Transform.
-# CAST(col AS int) and CAST(col as datetime) not required when using columns from a data warehouse table or SQL statement based off of a table. It is used here for BigQuery to resolve improperly cast STRING data when using "UNION ALL" data.
+# CAST(col AS int) and CAST(col as TIMESTAMP) not required when using columns from a data warehouse table or SQL statement based off of a table. It is used here for BigQuery to resolve improperly cast STRING data when using "UNION ALL" data.
   sql_query: |
     SELECT
       id_transaction
@@ -102,7 +102,7 @@ data_source: # This section includes metadata on the data source and the source 
       , id_customer
       , CAST(transaction_amount_usd AS int) AS transaction_amount_usd
       , transaction_type_name
-      , CAST(ds as datetime) as ds
+      , CAST(ds as TIMESTAMP) as ds
     FROM (
         SELECT
         's98356237'              AS id_transaction


### PR DESCRIPTION
# Changes
* Databricks doesn't support `DATETIME`, so here I'm switching to using `TIMESTAMP` type. Note that this will break some queries for Big Query, so we need to find a better long-term fix - but this is more urgent to ensure that new Databricks customers have a smooth experience.

# Testing
- [ ] Specs pass (or how you tested your changes)

# Security Implications
* Please put any possible security-related concerns here. Feel free to @andykram if you're unsure. If none, please put "None"


<!--
PR checklist – confirm the PR contains the following:

* appropriate testing
* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
